### PR TITLE
修复模态对话框问题

### DIFF
--- a/DmMain/inc/Core/DMApp.h
+++ b/DmMain/inc/Core/DMApp.h
@@ -47,10 +47,9 @@ namespace DM
 		/// -------------------------------------------------
 		/// @brief			运行消息循环
 		/// @param[in]		hMainWnd          窗口句柄
-		/// @param[in]		bEnableActive     是否强制enalbe窗口(用于DoModal)
 		/// @remark         在窗口创建后，运行消息循环
 		/// @return			DMCode
-		DMCode Run(HWND hMainWnd,bool bEnableActive=false);
+		DMCode Run(HWND hWnd);
 
 		/// -------------------------------------------------
 		/// @brief			此窗口是否为运行消息循环的主窗口   

--- a/DmMain/inc/Core/DMAppData.h
+++ b/DmMain/inc/Core/DMAppData.h
@@ -71,7 +71,7 @@ namespace DM
 		virtual~DMAppData();
 
 		DMCode InitGlobal(LPCWSTR lpszXmlId);
-		DMCode Run(HWND hMainWnd,bool bEnableActive);
+		DMCode Run(HWND hWnd);
 		DMCode IsRun(HWND hWnd);
 		//---------------------------------------------------
 		// Function Des: ×¢²áÀà

--- a/DmMain/inc/Core/DMHDialog.h
+++ b/DmMain/inc/Core/DMHDialog.h
@@ -25,9 +25,7 @@ namespace DM
 		DMDECLARE_CLASS_NAME(DMHDialog,L"hdialog",DMREG_Window);
 	public:
 		DMHDialog();
-		virtual~DMHDialog();
 
-	public:
 		virtual INT_PTR DoModal(LPCWSTR lpszXmlId, HWND hParent=NULL, bool bShadow=false,DM::CRect rect=DM::CRect(0,0,0,0));
 		void EndDialog(INT_PTR nResult);
 

--- a/DmMain/src/Core/DMApp.cpp
+++ b/DmMain/src/Core/DMApp.cpp
@@ -35,9 +35,9 @@ namespace DM
 		return g_pDMAppData->InitGlobal(lpszXmlId);
 	}
 
-	DMCode DMApp::Run(HWND hMainWnd,bool bEnableActive)
+	DMCode DMApp::Run(HWND hWnd)
 	{
-		return g_pDMAppData->Run(hMainWnd,bEnableActive);
+		return g_pDMAppData->Run(hWnd);
 	}
 
 	DMCode DMApp::IsRun(HWND hWnd)

--- a/DmMain/src/Core/DMAppData.cpp
+++ b/DmMain/src/Core/DMAppData.cpp
@@ -90,7 +90,7 @@ namespace DM
 		return iErr;
 	}
 
-	DMCode DMAppData::Run(HWND hMainWnd,bool bEnableActive)
+	DMCode DMAppData::Run(HWND hWnd)
 	{
 		LOG_INFO("[start]\n");
 		DMCode iErr = DM_ECODE_FAIL;
@@ -113,29 +113,19 @@ namespace DM
 				pMsgLoop->AddRef(); // 引用计数+1
 			}
 
-			HWND hLastMainWnd = ::GetActiveWindow();
-			if (::IsWindow(hMainWnd))
-			{
-				if (!(::GetWindowLong(hMainWnd, GWL_EXSTYLE) & WS_EX_TOOLWINDOW))
-				{// 有WS_EX_TOOLWINDOW属性的不强制设置激活
-					hLastMainWnd = ::SetActiveWindow(hMainWnd);
-				}
-			}
-			size_t index = m_RunhWndArray.Add(hMainWnd);// 用于DestroyWindow中判断是否发送WM_QUIT消息 
+			// HWND hLastMainWnd = ::GetActiveWindow();
+			// if (::IsWindow(hWnd))
+			// {
+			// 	if (!(::GetWindowLong(hWnd, GWL_EXSTYLE) & WS_EX_TOOLWINDOW))
+			// 	{// 有WS_EX_TOOLWINDOW属性的不强制设置激活
+			// 		hLastMainWnd = ::SetActiveWindow(hWnd);
+			// 	}
+			// }
+			size_t index = m_RunhWndArray.Add(hWnd);// 用于DestroyWindow中判断是否发送WM_QUIT消息 
 			pMsgLoop->Run();
-			if (::IsWindow(hLastMainWnd)&&bEnableActive) 
-			{
-				::EnableWindow(hLastMainWnd,true);
-			}
-			if (index<m_RunhWndArray.GetCount()&&hMainWnd == m_RunhWndArray[index])
+			if (index<m_RunhWndArray.GetCount() && hWnd == m_RunhWndArray[index])
 			{
 				m_RunhWndArray.RemoveAt(index);
-			}
-			::SetActiveWindow(hLastMainWnd);
-
-			if(::IsWindow(hMainWnd)) 
-			{
-				DestroyWindow(hMainWnd);
 			}
 
 			if (pMsgLoop->GetRefCount()>1)

--- a/DmMain/src/Core/DMHDialog.cpp
+++ b/DmMain/src/Core/DMHDialog.cpp
@@ -20,10 +20,6 @@ namespace DM
 		m_nRetCode = -1;
 	}
 
-	DMHDialog::~DMHDialog()
-	{
-	}
-
 	INT_PTR DMHDialog::DoModal(LPCWSTR lpszXmlId, HWND hWndParent/*=NULL*/, bool bShadow/*=false*/, DM::CRect rect/* = NULL*/)
 	{
 		BOOL bEnableParent = FALSE;

--- a/DmMain/src/Core/DMHDialog.cpp
+++ b/DmMain/src/Core/DMHDialog.cpp
@@ -46,7 +46,7 @@ namespace DM
 			HWND_NOTOPMOST：将窗口置于所有非顶层窗口之上（即在所有顶层窗口之后）。如果窗口已经是非顶层窗口则该标志不起作用。
 			HWND_TOP:将窗口置于Z序的顶部。
 			*/
-			::SetWindowPos(m_hWnd, /*HWND_TOP*/HWND_NOTOPMOST, 0, 0, 0, 0, SWP_NOSIZE | SWP_NOMOVE | SWP_SHOWWINDOW | SWP_NOACTIVATE);
+			::SetWindowPos(m_hWnd, /*HWND_TOP*/HWND_NOTOPMOST, 0, 0, 0, 0, SWP_NOSIZE | SWP_NOMOVE | SWP_SHOWWINDOW);
 			g_pDMApp->Run(m_hWnd); // RunModalLoop, 这里没有和mfc一样利用m_nFlags标记检查ContinueModal
 
 			// [mfc] hide the window before enabling the parent, etc.


### PR DESCRIPTION
- [x] 对话框关闭后，父窗口会被系统置其他进程非禁用状态窗口之后
- [x] 对话框展示后，未处于激活状态